### PR TITLE
Feat: 환율 API 로딩 자동화, api key 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 .DS_Store
+src/main/resources/application-secrets.yml

--- a/src/main/java/com/example/fisafroexpay/FisaFroexPayApplication.java
+++ b/src/main/java/com/example/fisafroexpay/FisaFroexPayApplication.java
@@ -3,8 +3,9 @@ package com.example.fisafroexpay;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class FisaFroexPayApplication {
 

--- a/src/main/java/com/example/fisafroexpay/service/ExchangeRateService.java
+++ b/src/main/java/com/example/fisafroexpay/service/ExchangeRateService.java
@@ -6,6 +6,7 @@ import com.example.fisafroexpay.repository.ExchangeRateRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -97,15 +98,18 @@ public class ExchangeRateService {
     /**
      * 현재 날짜에 자동 매핑되는 코드입니다
      **/
-//    private static String getCurrentDate() {
-//        LocalDate today = LocalDate.now(); // 현재 날짜
-//        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd"); // 날짜 형식
-//        return today.format(formatter); // 날짜를 문자열로 포맷
-//    }
+    private static String getCurrentDate() {
+        LocalDate today = LocalDate.now(); // 현재 날짜
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd"); // 날짜 형식
+        return today.format(formatter); // 날짜를 문자열로 포맷
+    }
 
-
-//    public void m1() {
-        // TODO: 1시간마다 Service 단 메서드 호출하기
-//        saveExchangeRateDTO(parseExchangeRateData(fetchExchangeRateData()));
-//    }
+    // 1시간에 한 번씩
+    @Scheduled(cron = "0 0 * * * ?")
+    public void execute() {
+        logger.info("cron");
+        String jsonString = fetchExchangeRateData();
+        List<ExchangeRateDTO> exchangeRateDTOs = parseExchangeRateData(jsonString);
+        saveExchangeRateDTO(exchangeRateDTOs);
+    }
 }

--- a/src/main/java/com/example/fisafroexpay/service/ExchangeRateService.java
+++ b/src/main/java/com/example/fisafroexpay/service/ExchangeRateService.java
@@ -6,6 +6,7 @@ import com.example.fisafroexpay.repository.ExchangeRateRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -22,14 +23,14 @@ import java.util.stream.Collectors;
 public class ExchangeRateService {
 
     private static final Logger logger = Logger.getLogger(ExchangeRateService.class.getName());
-    private static final String authkey = "7zNlvx0a71eFW32VdPuw3RIPgGOKk45p";
-    public static String date = "20240813"; // getCurrentDate();
-    private static final String API_URL = "https://www.koreaexim.go.kr/site/program/financial/exchangeJSON?authkey=" + authkey + "&searchdate=" + date + "&data=AP01";
-
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final RestTemplate restTemplate = new RestTemplate();
 
     private final ExchangeRateRepository exchangeRateRepository;
+
+    @Value("${api.key}")
+    private String authkey;
+
 
     @Autowired
     public ExchangeRateService(ExchangeRateRepository exchangeRateRepository) {
@@ -43,7 +44,7 @@ public class ExchangeRateService {
      */
     public String fetchExchangeRateData() {
         try {
-            String response = restTemplate.getForObject(API_URL, String.class);
+            String response = restTemplate.getForObject(getUrl(), String.class);
             if (response != null) {
                 return response;
             } else {
@@ -104,6 +105,11 @@ public class ExchangeRateService {
         return today.format(formatter); // 날짜를 문자열로 포맷
     }
 
+    private String getUrl(){
+        String date = getCurrentDate();
+        return "https://www.koreaexim.go.kr/site/program/financial/exchangeJSON?authkey=" + authkey + "&searchdate=" + date + "&data=AP01";
+
+    }
     // 1시간에 한 번씩
     @Scheduled(cron = "0 0 * * * ?")
     public void execute() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
 
+  config:
+    import: application-secrets.yml
+
 springdoc:
   swagger-ui:
     groups-order: DESC

--- a/src/test/java/com/example/fisafroexpay/FisaFroexPayApplicationTests.java
+++ b/src/test/java/com/example/fisafroexpay/FisaFroexPayApplicationTests.java
@@ -2,7 +2,9 @@ package com.example.fisafroexpay;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootTest
 class FisaFroexPayApplicationTests {
 


### PR DESCRIPTION
## #️⃣연관된 이슈

>#13, #21 

## 📝작업 내용

- `@Scheduled` Annotation과 cron 표현식을 통해 1시간에 1번씩 수출입은행 API 로딩하여 데이터베이스에 적재
- api key 분리(application-secret.yml), `.gitignore`에 추가