### PR TITLE
Fix: 환율 API 데이터 가공 방식 수정

### DIFF
--- a/src/main/java/com/example/fisafroexpay/entity/ExchangeRate.java
+++ b/src/main/java/com/example/fisafroexpay/entity/ExchangeRate.java
@@ -5,11 +5,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+
 import java.math.BigDecimal;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.math.RoundingMode;
+
+import lombok.*;
 import org.hibernate.envers.AuditOverride;
 
 @Entity
@@ -18,6 +18,7 @@ import org.hibernate.envers.AuditOverride;
 @NoArgsConstructor
 @AllArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
+@ToString
 public class ExchangeRate extends BaseEntity {
 
     @Id
@@ -28,4 +29,15 @@ public class ExchangeRate extends BaseEntity {
     private String targetCurrency;
     @Column(nullable = false, scale = 2)
     private BigDecimal baseExchangeRate;
+
+    // 엔화만 100엔 당 n원 방식으로 저장되기 때문에 변경해야 할 필요 존재.
+    public void convertJpyRate() {
+        if ("JPY(100)".equals(this.targetCurrency)) {
+            this.baseExchangeRate = this.baseExchangeRate.divide(
+                    BigDecimal.valueOf(100),
+                    2,
+                    RoundingMode.HALF_EVEN);
+        }
+
+    }
 }

--- a/src/main/java/com/example/fisafroexpay/service/ExchangeRateService.java
+++ b/src/main/java/com/example/fisafroexpay/service/ExchangeRateService.java
@@ -127,15 +127,21 @@ public class ExchangeRateService {
     public Map<String, BigDecimal> getNewestCurrencyRateMap(){
 
         ExchangeRate rateUSD = exchangeRateRepository.findByTargetCurrency("USD");
-        ExchangeRate rateCNY = exchangeRateRepository.findByTargetCurrency("CNY");
-        ExchangeRate rateJPY = exchangeRateRepository.findByTargetCurrency("JPY");
+        ExchangeRate rateCNY = exchangeRateRepository.findByTargetCurrency("CNH");
+        ExchangeRate rateJPY = exchangeRateRepository.findByTargetCurrency("JPY(100)");
+        rateJPY.convertJpyRate();
         ExchangeRate rateEUR = exchangeRateRepository.findByTargetCurrency("EUR");
+
+
 
         Map<String, BigDecimal> map = new HashMap<>();
         map.put("USD", rateUSD.getBaseExchangeRate());
         map.put("CNY", rateCNY.getBaseExchangeRate());
         map.put("JPY", rateJPY.getBaseExchangeRate());
         map.put("EUR", rateEUR.getBaseExchangeRate());
+
+        logger.info(map.toString());
+
 
         return map;
     }


### PR DESCRIPTION
## 어떤 작업인가요?
> 환율 API 데이터 가공 방식 수정

## 작업 내용

### 1. 환율 데이터 DB 저장 방식 확인
![image](https://github.com/user-attachments/assets/dab43a87-3129-4b7e-877b-0638a9736957)

엔화는 DB에 저장될 때 `JPY` 형태로 저장되는 것이 아니라 `JPY(100)` 형태로 DB에 저장된다.
가져올 때 로직 수정 필요.
```java
ExchangeRate rateJPY = exchangeRateRepository.findByTargetCurrency("JPY(100)");

```
<img width="906" alt="image" src="https://github.com/user-attachments/assets/72063e89-92f8-4652-9326-e6b321ea00d3">

또한 중국 위안화는 `CNY`가 아니라 `CNH`로 저장되기 때문에 불러오는 로직 수정.
하지만 우리 프로젝트 코드에서는 CNY로 표기하고, DB에서 불러올 때만 "CNH" 를 사용한다.

```java
ExchangeRate rateCNY = exchangeRateRepository.findByTargetCurrency("CNH");
```
### 2. 엔화 환율 계산 방식 적용
엔화는 1엔 당 n원 으로 계산되는 것이 아니라, 100엔 당 933원 형태로 계산된다.
따라서 가져온 데이터를 가공해야 할 필요가 있다.

```java
// 엔화만 100엔 당 n원 방식으로 저장되기 때문에 변경해야 할 필요 존재.
public void convertJpyRate() {
    if ("JPY(100)".equals(this.targetCurrency)) {
        this.baseExchangeRate = this.baseExchangeRate.divide(
                BigDecimal.valueOf(100),
                2,
                RoundingMode.HALF_EVEN);
    }
}
```