### PR TITLE
Feat: transfer.html 비동기 데이터 fetch 처리

### DIFF
--- a/src/main/java/com/example/fisafroexpay/controller/TransferController.java
+++ b/src/main/java/com/example/fisafroexpay/controller/TransferController.java
@@ -1,25 +1,25 @@
 package com.example.fisafroexpay.controller;
 
-import com.example.fisafroexpay.dto.SecurityUser;
-import com.example.fisafroexpay.dto.TransferRequest;
-import com.example.fisafroexpay.dto.TransferResponse;
+import com.example.fisafroexpay.dto.*;
+import com.example.fisafroexpay.entity.ExchangeDetail;
 import com.example.fisafroexpay.entity.TransferDetail;
+import com.example.fisafroexpay.service.ExchangeService;
 import com.example.fisafroexpay.service.TransferService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/transfer")
+@CrossOrigin(origins = "*")
 public class TransferController {
 
-
+  private final ExchangeService exchangeService;
   private final TransferService transferService;
 
   // 1단계: 계산 결과 반환
@@ -48,5 +48,13 @@ public class TransferController {
   public ResponseEntity<TransferResponse> tradeConfirm(@AuthenticationPrincipal SecurityUser user) {
     TransferResponse transferDetail = transferService.getTransferDetail(user.getUser());
     return ResponseEntity.ok(transferDetail);
+  }
+
+  @PostMapping("/calculate")
+  @ResponseBody
+  public ResponseEntity<ReceiveAmountResponse> getFinalAmount(@RequestBody ReceiveAmountRequest request){
+    ExchangeDetail exchangeDetail = exchangeService.createExchangeDetail(request.getAmount(), request.getCurrencyCode());
+    ReceiveAmountResponse response = transferService.getReceiveAmount(request.getCurrencyCode(), exchangeDetail);
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/example/fisafroexpay/dto/ReceiveAmountRequest.java
+++ b/src/main/java/com/example/fisafroexpay/dto/ReceiveAmountRequest.java
@@ -1,0 +1,17 @@
+package com.example.fisafroexpay.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ReceiveAmountRequest {
+    private String currencyCode;
+    private Long amount;
+}

--- a/src/main/java/com/example/fisafroexpay/dto/ReceiveAmountResponse.java
+++ b/src/main/java/com/example/fisafroexpay/dto/ReceiveAmountResponse.java
@@ -1,0 +1,17 @@
+package com.example.fisafroexpay.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ReceiveAmountResponse {
+    private String currencyCode;
+    private BigDecimal amount;
+}

--- a/src/main/java/com/example/fisafroexpay/entity/ExchangeRate.java
+++ b/src/main/java/com/example/fisafroexpay/entity/ExchangeRate.java
@@ -31,7 +31,7 @@ public class ExchangeRate extends BaseEntity {
     private BigDecimal baseExchangeRate;
 
     // 엔화만 100엔 당 n원 방식으로 저장되기 때문에 변경해야 할 필요 존재.
-    public void convertJpyRate() {
+    public void convertRateIfJpy() {
         if ("JPY(100)".equals(this.targetCurrency)) {
             this.baseExchangeRate = this.baseExchangeRate.divide(
                     BigDecimal.valueOf(100),

--- a/src/main/java/com/example/fisafroexpay/entity/ExchangeRate.java
+++ b/src/main/java/com/example/fisafroexpay/entity/ExchangeRate.java
@@ -5,11 +5,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+
 import java.math.BigDecimal;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.math.RoundingMode;
+
+import lombok.*;
 import org.hibernate.envers.AuditOverride;
 
 @Entity
@@ -18,6 +18,7 @@ import org.hibernate.envers.AuditOverride;
 @NoArgsConstructor
 @AllArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
+@ToString
 public class ExchangeRate extends BaseEntity {
 
     @Id
@@ -28,4 +29,15 @@ public class ExchangeRate extends BaseEntity {
     private String targetCurrency;
     @Column(nullable = false, scale = 2)
     private BigDecimal baseExchangeRate;
+
+    // 엔화만 100엔 당 n원 방식으로 저장되기 때문에 변경해야 할 필요 존재.
+    public void convertJpyRate() {
+        if ("JPY(100)".equals(this.targetCurrency)) {
+            this.baseExchangeRate = this.baseExchangeRate.divide(
+                    BigDecimal.valueOf(100),
+                    2,
+                    RoundingMode.HALF_EVEN);
+        }
+
+    }
 }

--- a/src/main/java/com/example/fisafroexpay/repository/ExchangeRateRepository.java
+++ b/src/main/java/com/example/fisafroexpay/repository/ExchangeRateRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 @Repository
 public interface ExchangeRateRepository extends JpaRepository<ExchangeRate, Long> {
 
-    ExchangeRate findByTargetCurrency(String targetCurrency);
+    @Query("SELECT e FROM ExchangeRate e WHERE e.targetCurrency = :targetCurrency ORDER BY e.createdAt DESC")
+    ExchangeRate findByTargetCurrency(@Param("targetCurrency") String targetCurrency);
 
 }

--- a/src/main/java/com/example/fisafroexpay/service/ExchangeRateService.java
+++ b/src/main/java/com/example/fisafroexpay/service/ExchangeRateService.java
@@ -129,7 +129,7 @@ public class ExchangeRateService {
         ExchangeRate rateUSD = exchangeRateRepository.findByTargetCurrency("USD");
         ExchangeRate rateCNY = exchangeRateRepository.findByTargetCurrency("CNH");
         ExchangeRate rateJPY = exchangeRateRepository.findByTargetCurrency("JPY(100)");
-        rateJPY.convertJpyRate();
+        rateJPY.convertRateIfJpy();
         ExchangeRate rateEUR = exchangeRateRepository.findByTargetCurrency("EUR");
 
 

--- a/src/main/java/com/example/fisafroexpay/service/ExchangeRateService.java
+++ b/src/main/java/com/example/fisafroexpay/service/ExchangeRateService.java
@@ -127,15 +127,21 @@ public class ExchangeRateService {
     public Map<String, BigDecimal> getNewestCurrencyRateMap(){
 
         ExchangeRate rateUSD = exchangeRateRepository.findByTargetCurrency("USD");
-        ExchangeRate rateCNY = exchangeRateRepository.findByTargetCurrency("CNY");
-        ExchangeRate rateJPY = exchangeRateRepository.findByTargetCurrency("JPY");
+        ExchangeRate rateCNY = exchangeRateRepository.findByTargetCurrency("CNH");
+        ExchangeRate rateJPY = exchangeRateRepository.findByTargetCurrency("JPY(100)");
+        rateJPY.convertJpyRate();
         ExchangeRate rateEUR = exchangeRateRepository.findByTargetCurrency("EUR");
+
+
 
         Map<String, BigDecimal> map = new HashMap<>();
         map.put("USD", rateUSD.getBaseExchangeRate());
         map.put("CNY", rateCNY.getBaseExchangeRate());
         map.put("JPY", rateJPY.getBaseExchangeRate());
         map.put("EUR", rateEUR.getBaseExchangeRate());
+
+        logger.info(map.toString());
+
 
         return map;
     }

--- a/src/main/java/com/example/fisafroexpay/service/TransferService.java
+++ b/src/main/java/com/example/fisafroexpay/service/TransferService.java
@@ -1,5 +1,6 @@
 package com.example.fisafroexpay.service;
 
+import com.example.fisafroexpay.dto.ReceiveAmountResponse;
 import com.example.fisafroexpay.dto.TransferRequest;
 import com.example.fisafroexpay.dto.TransferResponse;
 import com.example.fisafroexpay.entity.Account;
@@ -48,6 +49,7 @@ public class TransferService {
         // 환율 계산 (환전 서비스 호출)
         ExchangeDetail exchangeDetail = exchangeService.createExchangeDetail(req.getAmount(),
             req.getReceiverCurrencyCode());
+        exchangeDetail = exchangeService.saveExchangeDetail(exchangeDetail);
 
         // 송금 수수료 계산(외화) = 환율 * 5000원
         BigDecimal transferFee =
@@ -133,6 +135,21 @@ public class TransferService {
             .currencyCode(transferDetail.getCurrencyCode())
             .transferredAmount(transferDetail.getLastAmount())
             .totalTransferFee(transferDetail.getTransferFee()).build();
+    }
+
+
+    public ReceiveAmountResponse getReceiveAmount(String currencyCode, ExchangeDetail exchangeDetail){
+        BigDecimal transferFee =
+                TRANSFER_FEE_KRW.divide(exchangeDetail.getExchangeRate().getBaseExchangeRate(), 2,
+                        RoundingMode.HALF_EVEN);
+
+        BigDecimal exchangedAmount = exchangeDetail.getFinalAmount();
+        BigDecimal lastAmount = exchangedAmount.subtract(transferFee);
+
+
+        return new ReceiveAmountResponse(currencyCode, lastAmount);
+
+
     }
 
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -325,6 +325,8 @@
                 document.getElementById("continue-btn").textContent = "송금하기";
                 document.getElementById("continue-btn").addEventListener("click", function() {
                     localStorage.setItem("transferAmount", document.getElementById('you-send').value.replace(/,/g, ''));
+                    localStorage.setItem("code", document.getElementById('currency-dropdown').textContent);
+                    console.log(document.getElementById('currency-dropdown').textContent);
                     window.location.href = 'transfer.html';
                 });
             }

--- a/src/main/resources/static/transfer.html
+++ b/src/main/resources/static/transfer.html
@@ -133,7 +133,7 @@
             <div class="input-group">
                 <input type="text" id="amount" name="amount">
                 <div class="dropdown">
-                    <button class="dropbtn" id="send-currency">KRW</button>
+                    <div class="dropbtn" id="send-currency">KRW</div>
                     <div class="dropdown-content" id="send-currency-options">
                         <a href="#" onclick="selectSendCurrency('KRW')">KRW</a>
                         <a href="#" onclick="selectSendCurrency('USD')">USD</a>
@@ -157,7 +157,7 @@
             <div class="input-group">
                 <input type="text" id="receive-amount" name="receiveAmount" readonly>
                 <div class="dropdown">
-                    <button class="dropbtn" id="receiverCurrencyCode">USD</button>
+                    <div class="dropbtn" id="receiverCurrencyCode">USD</div>
                     <div class="dropdown-content" id="receiverCurrencyCode2">
                         <a href="#" onclick="selectCurrency('USD')">USD</a>
                         <a href="#" onclick="selectCurrency('JPY')">JPY</a>
@@ -189,8 +189,12 @@
 
     document.addEventListener("DOMContentLoaded", function() {
         const sendAmount = localStorage.getItem("transferAmount");
+        const code = localStorage.getItem("code").valueOf();
+        console.log(code);
         if (sendAmount) {
-            document.getElementById('send-amount').value = formatNumber(sendAmount);
+            document.getElementById('amount').value = sendAmount;
+            document.getElementById('receiverCurrencyCode').textContent = code;
+
             calculateReceiveAmount();
         }
 
@@ -213,12 +217,13 @@
 
     function selectCurrency(currency) {
         document.getElementById('receiverCurrencyCode').textContent = currency;
-
-        const amount = parseFloat(document.getElementById('amount').value.replace(/,/g, '')) || 0;
-        const rate = exchangeRates[currency] || 1;
-        const convertedAmount = (amount / rate).toFixed(2);
-
-        document.getElementById('receive-amount').value = formatNumber(convertedAmount);
+        //
+        // const amount = parseFloat(document.getElementById('amount').value.replace(/,/g, '')) || 0;
+        // const rate = exchangeRates[currency] || 1;
+        // const convertedAmount = (amount / rate).toFixed(2);
+        //
+        // document.getElementById('receive-amount').value = formatNumber(convertedAmount);
+        calculateReceiveAmount()
     }
 
     function formatNumber(num) {
@@ -226,11 +231,41 @@
     }
 
     function calculateReceiveAmount() {
+
         const sendAmount = parseFloat(localStorage.getItem("transferAmount")) || 0;
-        const receiveCurrency = document.getElementById('receive-currency').textContent;
-        const rate = exchangeRates[receiveCurrency] || 1;
-        const convertedAmount = (sendAmount / rate).toFixed(2);
-        document.getElementById('receive-amount').value = formatNumber(convertedAmount);
+        const receiveCurrency = document.getElementById('receiverCurrencyCode').textContent;
+
+        const requestPayload = {
+            currencyCode: receiveCurrency,
+            amount: sendAmount
+        };
+
+        fetch('/transfer/calculate', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(requestPayload)
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response is not ok');
+                }
+                return response.json();
+            })
+            .then(data=>{
+                if (data && data.amount !== undefined){
+                    document.getElementById('receive-amount').value = data.amount;
+                }else{
+                    console.error('Unexpected format:', data);
+                }
+
+            })
+            .catch(error => console.error('Error:', error));
+
+        // const rate = exchangeRates[receiveCurrency] || 1;
+        // const convertedAmount = (sendAmount / rate).toFixed(2);
+        // document.getElementById('receive-amount').value = formatNumber(convertedAmount);
     }
 
     function selectSendCurrency(currency) {


### PR DESCRIPTION
## 연관된 이슈
#58 

## 작업 내용

- index.html에서 입력한 송금 금액, 통화 코드 저장
- transfer.html의 입력 form에 자동 입력
- 입력되는 금액은 수수료 제외한 금액
- JPY(100) 오류 수정
- 비동기 처리로 로직 구현
- CORS 문제 고려

### index.html
![image](https://github.com/user-attachments/assets/1d4963e1-2bfd-489b-9758-f36118e06f01)
메인 화면에서 100000 KRW 입력 시 72.98 USD (환전 수수료 고려)

![image](https://github.com/user-attachments/assets/29f9caa3-bb76-499b-b491-7f3ff2ef3dcf)
송금 화면에서 그대로 가져오되, 송금 수수료 고려하여 68.24 USD

