### PR TITLE
Fix: ExchangeRateRepository 데이터 중복 로직 수정

### DIFF
--- a/src/main/java/com/example/fisafroexpay/repository/ExchangeRateRepository.java
+++ b/src/main/java/com/example/fisafroexpay/repository/ExchangeRateRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 @Repository
 public interface ExchangeRateRepository extends JpaRepository<ExchangeRate, Long> {
 
-    @Query("SELECT e FROM ExchangeRate e WHERE e.targetCurrency = :targetCurrency ORDER BY e.createdAt DESC")
+    @Query("SELECT e FROM ExchangeRate e WHERE e.targetCurrency = :targetCurrency ORDER BY e.createdAt DESC LIMIT 1")
     ExchangeRate findByTargetCurrency(@Param("targetCurrency") String targetCurrency);
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/ffp
     username: root
-    password: 12
+    password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
## 어떤 작업인가요?
> ExchangeRateRepository 데이터 2개 이상 가져오는 현상 수정

## 작업 내용
통화 내역 DB에 2개 이상인 경우 동작 로직 수정
- limit 1 쿼리에 추가